### PR TITLE
Refactor connection to prismic API

### DIFF
--- a/shared/MainApp.js
+++ b/shared/MainApp.js
@@ -5,7 +5,7 @@ import { Switch, Route, Link } from 'react-router-dom';
 import { inject } from 'mobx-react';
 import { withJob } from 'react-jobs';
 import config from 'utils/config';
-import { getField } from 'utils/prismic';
+import { get } from 'utils/prismic';
 
 // Layout
 import AppLayout, { Content } from 'components/app-layout';
@@ -34,6 +34,7 @@ import Search from './routes/search';
 import NotFound from './routes/not-found';
 
 class App extends Component {
+
   static propTypes = {
     jobResult: PropTypes.object,
   }
@@ -43,7 +44,7 @@ class App extends Component {
 
     const customPages = jobResult.data.custom_pages
       .map(({ custom_page: { uid, data: { title } } }) => (
-        <Link key={uid} to={`/${uid}`}>{getField(title, 'text')}</Link>
+        <Link key={uid} to={`/${uid}`}>{get(title)}</Link>
       ));
 
     return [
@@ -92,7 +93,7 @@ class App extends Component {
 }
 
 const appWithJob = withJob({
-  work: ({ prismic }) => prismic.getSingleByType({ type: 'homepage', links: 'custom_page.title' }),
+  work: ({ prismic }) => prismic.getCustomPages(),
 })(App);
 
 export default inject('prismic')(appWithJob);

--- a/shared/components/quote/Quote.js
+++ b/shared/components/quote/Quote.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getField } from 'utils/prismic';
+import { getRichtext } from 'utils/prismic';
 
 import s from './Quote.scss';
 
@@ -11,7 +11,7 @@ const Quote = ({ text }) => (
       <div className={s.quote__row}>
         <div className={s.quote__col}>
           <blockquote className={s.quote__block}>
-            {getField(text, 'richtext')}
+            {getRichtext(text)}
           </blockquote>
         </div>
       </div>

--- a/shared/components/slices/Slices.js
+++ b/shared/components/slices/Slices.js
@@ -11,6 +11,7 @@ const Slices = ({ data, className }) => (
   <div className={className}>
     {data.map((s, i) => {
       const key = `slice-${s.slice_type}-${i}`;
+
       switch (s.slice_type) {
         case 'image':
           return (<ImageContainer key={key} data={s.primary} />);

--- a/shared/components/slices/image-container/ImageContainer.js
+++ b/shared/components/slices/image-container/ImageContainer.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 
 import Image from 'components/image';
 
-import { getField } from 'utils/prismic';
+import { getRichtext } from 'utils/prismic';
 
 const ImageContainer = ({ data }) => {
   const { width, height } = data.image.dimensions;
   const { alt, url } = data.image;
-  const caption = getField(data.caption, 'richtext');
+  const caption = getRichtext(data, 'caption');
 
   return (
     <Image

--- a/shared/components/slices/video-container/VideoContainer.js
+++ b/shared/components/slices/video-container/VideoContainer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import Video from 'components/video';
-import { getField } from 'utils/prismic';
+import { getRichtext } from 'utils/prismic';
 
 export default class VideoContainer extends Component {
   static propTypes = {
@@ -11,7 +11,7 @@ export default class VideoContainer extends Component {
 
   render() {
     const { data } = this.props;
-    const caption = getField(data.caption, 'richtext');
+    const caption = getRichtext(data, 'caption');
 
     return (
       <Video

--- a/shared/components/text/Text.js
+++ b/shared/components/text/Text.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getField } from 'utils/prismic';
+import { getRichtext } from 'utils/prismic';
 
 import s from './Text.scss';
 
@@ -10,7 +10,7 @@ const Text = ({ text }) => (
     <div className={s.text__container}>
       <div className={s.text__row}>
         <div className={s.text__col}>
-          {getField(text, 'richtext')}
+          {getRichtext(text)}
         </div>
       </div>
     </div>

--- a/shared/routes/about/About.js
+++ b/shared/routes/about/About.js
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet';
 import { inject } from 'mobx-react';
 import { withJob } from 'react-jobs';
 
-import { getField } from 'utils/prismic';
+import { get, getCollection, getObject } from 'utils/prismic';
 
 import Intro from 'components/intro';
 import Peoples, { People } from './components/peoples';
@@ -24,28 +24,28 @@ class About extends PureComponent {
   render() {
     const { jobResult: about } = this.props;
 
-    const people = getField(about.data.people);
+    const people = getCollection(about.data.people);
 
     return (
       <div>
         <Helmet
-          title={getField(about.data.title_seo, 'text').trim()}
-          meta={[{ name: 'description', content: getField(about.data.description_seo, 'text').trim() }]}
+          title={get(about, 'data.title_seo')}
+          meta={[{ name: 'description', content: get(about, 'data.description_seo') }]}
         />
 
         <Intro>
-          <h1>{getField(about.data.title, 'text')}</h1>
-          <h2>{getField(about.data.subheading, 'text')}</h2>
-          <p>{getField(about.data.text, 'text')}</p>
+          <h1>{get(about, 'data.title')}</h1>
+          <h2>{get(about, 'data.subheading')}</h2>
+          <p>{get(about, 'data.text')}</p>
         </Intro>
 
-        <Peoples title={getField(about.data.people_title, 'text')}>
-          {people && people.map(({ person: { data: { name, bio, image } } }, i) => (
+        <Peoples title={get(about, 'data.people_title')}>
+          {people.map(({ person: { data: { name, bio, image } } }, i) => (
             <People
               key={`people-${i}`} // eslint-disable-line
-              image={getField(image).url}
-              name={getField(name, 'text')}
-              description={getField(bio, 'text')}
+              image={getObject(image).url}
+              name={get(name)}
+              description={get(bio)}
             />
           ))}
         </Peoples>
@@ -55,7 +55,7 @@ class About extends PureComponent {
 }
 
 const aboutWithJob = withJob({
-  work: ({ prismic }) => prismic.getSingleByType({ type: 'about', links: 'author.name,author.bio,author.image' }),
+  work: ({ prismic }) => prismic.getAbout(),
   LoadingComponent: () => (
     <div>
       <Intro isLoading />

--- a/shared/routes/articles/article-list/ArticleList.js
+++ b/shared/routes/articles/article-list/ArticleList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { inject } from 'mobx-react';
 import { withJob } from 'react-jobs';
-import { getField } from 'utils/prismic';
+import { get, getObject } from 'utils/prismic';
 
 import Intro from 'components/intro';
 import List, { Item } from './components/list';
@@ -20,14 +20,14 @@ class Articles extends PureComponent {
     return (
       <div>
         <Helmet
-          title={getField(page.data.title_seo, 'text').trim()}
-          meta={[{ name: 'description', content: getField(page.data.description_seo, 'text').trim() }]}
+          title={get(page, 'data.title_seo')}
+          meta={[{ name: 'description', content: get(page, 'data.description_seo') }]}
         />
 
         <Intro>
-          <h1>{getField(page.data.title, 'text')}</h1>
-          <h2>{getField(page.data.subtitle, 'text')}</h2>
-          <p>{getField(page.data.text, 'text')}</p>
+          <h1>{get(page, 'data.title')}</h1>
+          <h2>{get(page, 'data.subtitle')}</h2>
+          <p>{get(page, 'data.text')}</p>
         </Intro>
 
         {articles && (
@@ -39,15 +39,15 @@ class Articles extends PureComponent {
                 return null;
               }
 
-              const image = getField(data.image);
+              const image = getObject(data, 'image');
               const src = image && image.url;
 
               return (
                 <Item
                   key={uid}
                   url={`/articles/${uid}`}
-                  title={getField(data.title, 'text')}
-                  description={getField(data.short_description, 'text')}
+                  title={get(data, 'title')}
+                  description={get(data, 'short_description')}
                   image={image}
                   src={src}
                 />
@@ -65,14 +65,7 @@ class Articles extends PureComponent {
 }
 
 const articlesWithJob = withJob({
-  work: async ({ prismic }) => {
-    const [page, articles] = await Promise.all([
-      prismic.getSingleByType({ type: 'articles', links: 'author.name,author.bio,author.image' }),
-      prismic.getByType({ type: 'article', links: 'author.name' }),
-    ]);
-
-    return { page, articles };
-  },
+  work: async ({ prismic }) => prismic.getArticles(),
   LoadingComponent: () => (
     <Intro isLoading />
   ),

--- a/shared/routes/articles/article/Article.js
+++ b/shared/routes/articles/article/Article.js
@@ -13,7 +13,7 @@ import Article from 'components/article';
 import Author from 'components/author';
 import Slices from 'components/slices';
 
-import { getField } from 'utils/prismic';
+import { get, getCollection, getObject } from 'utils/prismic';
 
 class Articles extends Component {
 
@@ -28,23 +28,23 @@ class Articles extends Component {
       return <Route component={NotFound} />;
     }
 
-    const title = getField(article.data.title, 'text');
-    const author = getField(article.data.author);
-    const body = getField(article.data.body, 'body');
+    const title = get(article, 'data.title');
+    const author = getObject(article, 'data.author');
+    const body = getCollection(article, 'data.body');
 
     return (
       <div>
         <Helmet
-          title={getField(article.data.title_seo, 'text').trim()}
-          meta={[{ name: 'description', content: getField(article.data.description_seo, 'text').trim() }]}
+          title={get(article, 'data.title_seo')}
+          meta={[{ name: 'description', content: get(article, 'data.description_seo')}]}
         />
 
         <Article>
           {author && (<Author
             key="author"
-            name={getField(author.data.name, 'text')}
-            bio={getField(author.data.bio, 'text')}
-            image={(getField(author.data.image) || {}).thumb}
+            name={get(author, 'data.name')}
+            bio={get(author, 'data.bio')}
+            image={getObject(author, 'data.image').thumb}
           />)}
           <Heading key="heading">{title}</Heading>
           <Slices data={body} />
@@ -56,11 +56,7 @@ class Articles extends Component {
 }
 
 const articlesWithJob = withJob({
-  work: ({ prismic, match }) => prismic.getByType({
-    type: 'article',
-    uid: match.params.id,
-    links: 'author.name,author.bio,author.image',
-  }),
+  work: ({ prismic, match }) => prismic.getArticle(match.params.id),
   LoadingComponent: () => (
     <Article>
       <Author

--- a/shared/routes/contact/Contact.js
+++ b/shared/routes/contact/Contact.js
@@ -6,7 +6,7 @@ import { inject, observer } from 'mobx-react';
 import { withJob } from 'react-jobs';
 import { autobind } from 'core-decorators';
 
-import { getField } from 'utils/prismic';
+import { get } from 'utils/prismic';
 
 import Intro from 'components/intro';
 import Segment from 'components/segment';
@@ -48,21 +48,21 @@ class Contact extends PureComponent {
     return (
       <div>
         <Helmet
-          title={getField(contact.data.title_seo, 'text').trim()}
-          meta={[{ name: 'description', content: getField(contact.data.description_seo, 'text').trim() }]}
+          title={get(contact, 'data.title_seo')}
+          meta={[{ name: 'description', content: get(contact, 'data.description_seo') }]}
         />
 
         <Intro>
-          <h1>{getField(contact.data.title, 'text')}</h1>
-          <h2>{getField(contact.data.subheading, 'text')}</h2>
-          <p>{getField(contact.data.text, 'text')}</p>
+          <h1>{get(contact, 'data.title')}</h1>
+          <h2>{get(contact, 'data.subheading')}</h2>
+          <p>{get(contact, 'data.text')}</p>
         </Intro>
 
         <Segment>
           {this.success ? (
             <Success
-              title={getField(contact.data.success_message_title, 'text')}
-              text={getField(contact.data.success_message_text, 'text')}
+              title={get(contact, 'data.success_message_title')}
+              text={get(contact, 'data.success_message_text')}
             />
           ) : (
             <ContactForm onSend={this.onSend} />
@@ -74,7 +74,7 @@ class Contact extends PureComponent {
 }
 
 const contactWithJob = withJob({
-  work: ({ prismic }) => prismic.getSingleByType({ type: 'contact' }),
+  work: ({ prismic }) => prismic.getContact(),
   LoadingComponent: () => (
     <div>
       <Intro isLoading />

--- a/shared/routes/custom-page/CustomPage.js
+++ b/shared/routes/custom-page/CustomPage.js
@@ -7,7 +7,7 @@ import { withJob } from 'react-jobs';
 import isEmpty from 'lodash/isEmpty';
 
 import NotFound from 'routes/not-found';
-import { getField } from 'utils/prismic';
+import { get, getCollection } from 'utils/prismic';
 
 import Intro from 'components/intro';
 import Slices from 'components/slices';
@@ -26,16 +26,16 @@ class CustomPage extends PureComponent {
       return <Route component={NotFound} />;
     }
 
-    const body = getField(page.data.body, 'body');
+    const body = getCollection(page, 'data.body');
 
     return (
       <div>
-        <Helmet title={getField(page.data.title, 'text')} />
+        <Helmet title={get(page, 'data.title')} />
 
         <Intro>
-          <h1>{getField(page.data.title, 'text')}</h1>
-          <h2>{getField(page.data.subheading, 'text')}</h2>
-          <p>{getField(page.data.text, 'text')}</p>
+          <h1>{get(page, 'data.title')}</h1>
+          <h2>{get(page, 'data.subheading')}</h2>
+          <p>{get(page, 'data.text')}</p>
         </Intro>
 
         <Article>
@@ -47,8 +47,7 @@ class CustomPage extends PureComponent {
 }
 
 const customPageWithJob = withJob({
-  work: ({ prismic, match }) =>
-    prismic.getByType({ type: 'custom_page', uid: match.params.id }),
+  work: ({ prismic, match }) => prismic.getCustomPage(match.params.id),
 
   shouldWorkAgain: (prevProps, nextProps) =>
     prevProps.match.params.id !== nextProps.match.params.id,

--- a/shared/routes/home/Home.js
+++ b/shared/routes/home/Home.js
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet';
 import { inject } from 'mobx-react';
 import { withJob } from 'react-jobs';
 
-import { getField } from 'utils/prismic';
+import { get, getCollection, getRichtext } from 'utils/prismic';
 
 import Segment from 'components/segment';
 import Button from 'components/button';
@@ -32,29 +32,29 @@ class Home extends PureComponent {
     return (
       <div>
         <Helmet
-          title={getField(homepage.data.title_seo, 'text').trim()}
-          meta={[{ name: 'description', content: getField(homepage.data.description_seo, 'text').trim() }]}
+          title={get(homepage, 'data.title_seo')}
+          meta={[{ name: 'description', content: get(homepage, 'data.description_seo') }]}
         />
 
-        <Hero carousel={getField(homepage.data.carousel)} />
+        <Hero carousel={getCollection(homepage, 'data.carousel')} />
 
         <Columns
-          heading={getField(homepage.data.column_title, 'text')}
-          subline={getField(homepage.data.column_subheading, 'text')}
+          heading={get(homepage, 'data.column_title')}
+          subline={get(homepage, 'data.column_subheading')}
         >
-          {getField(homepage.data.content_columns, 'group').map((item, i) => (
+          {getCollection(homepage, 'data.content_columns').map((item, i) => (
             <Column
               key={i} // eslint-disable-line
-              title={getField(item.title, 'text')}
-              text={getField(item.text, 'richtext')}
+              title={get(item, 'title')}
+              text={getRichtext(item, 'text')}
             />
           ))}
         </Columns>
 
         <Articles
-          title={getField(homepage.data.articles_title, 'text')}
-          subheading={getField(homepage.data.articles_subheading, 'text')}
-          articles={homepage.data.featured_articles}
+          title={get(homepage, 'data.articles_title')}
+          subheading={get(homepage, 'data.articles_subheading')}
+          articles={getCollection(homepage, 'data.featured_articles')}
           show={4}
         />
 

--- a/shared/routes/home/components/articles/Articles.js
+++ b/shared/routes/home/components/articles/Articles.js
@@ -5,8 +5,7 @@ import format from 'date-fns/format';
 import isEmpty from 'lodash/isEmpty';
 
 import { AuthorBlock } from 'components/author';
-import { getField } from 'utils/prismic';
-import { asText } from 'prismic-richtext';
+import { get, getObject } from 'utils/prismic';
 
 import s from './Articles.scss';
 
@@ -40,14 +39,14 @@ export default class Articles extends Component {
                 {articles.slice(0, show).map(({ article = {} }) => {
                   const { uid, data } = article;
 
-                  const itemTitle = getField(data.title, 'title').trim();
+                  const itemTitle = get(data, 'title').trim();
 
                   if (!uid || !itemTitle) {
                     return null;
                   }
 
                   const url = `/articles/${uid}`;
-                  const description = getField(data.short_description, 'title');
+                  const description = get(data, 'short_description');
                   const date = data.publication_date;
                   const { author } = data;
                   const hasAuthor = !isEmpty(author) && !isEmpty(author.data);
@@ -68,9 +67,9 @@ export default class Articles extends Component {
                             {hasAuthor && (
                               <div className={s.articles__author}>
                                 <AuthorBlock
-                                  name={getField(author.data.name, 'text')}
-                                  bio={getField(author.data.bio, 'text')}
-                                  image={(getField(author.data.image) || {}).thumb}
+                                  name={get(author, 'data.name')}
+                                  bio={get(author, 'data.bio')}
+                                  image={(getObject(author, 'data.image')).thumb}
                                 />
                               </div>
                             )}

--- a/shared/routes/home/components/hero/Hero.js
+++ b/shared/routes/home/components/hero/Hero.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { TimelineLite } from 'gsap';
 import { TransitionGroup } from 'react-transition-group';
 
-import { getField } from 'utils/prismic';
+import { get } from 'utils/prismic';
 
 import Content from './Content';
 import s from './Hero.scss';
@@ -11,6 +11,10 @@ import s from './Hero.scss';
 export default class Hero extends PureComponent {
   static propTypes = {
     carousel: PropTypes.array,
+  }
+
+  static defaultProps = {
+    carousel: [],
   }
 
   state = {
@@ -33,16 +37,18 @@ export default class Hero extends PureComponent {
     const { carousel } = this.props;
     const { current } = this.state;
 
+    const slide = carousel[current];
+
     return (
       <div className={s.hero} ref={(el) => { this.el = el; }}>
         <div className={s(s.hero__container, s.hero__top)}>
           <div className={s.hero__row}>
-            {carousel && (
+            {Array.isArray(carousel) && (
               <TransitionGroup className={s.hero__content}>
                 <Content
                   key={`content-slide-${current}`}
-                  title={getField(carousel[current].title, 'text')}
-                  text={getField(carousel[current].text, 'text')}
+                  title={get(slide, 'title')}
+                  text={get(slide, 'text')}
                 />
               </TransitionGroup>
             )}
@@ -51,13 +57,15 @@ export default class Hero extends PureComponent {
 
         <div className={s.hero__container}>
           <ul className={s.hero__pagination}>
-            {carousel && carousel.map((_, i) => (
-              <li // eslint-disable-line
-                onClick={() => this.changeSlide(i, getField(carousel[i].color))}
-                className={s(s.hero__item, { active: current === i })}
-                key={`pagination-item-${i}`} // eslint-disable-line
-              />
-            ))}
+            {Array.isArray(carousel) && carousel.map((c, i) => {
+              return (
+                <li // eslint-disable-line
+                  onClick={() => this.changeSlide(i, get(carousel[i], 'color'))}
+                  className={s(s.hero__item, { active: current === i })}
+                  key={`pagination-item-${i}`} // eslint-disable-line
+                />
+              )
+            })}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Moves calls from locally proxied calls to calling the prismic API. Also refactors the "prismic helper" to use lodash get along with the methods from prismic helpers (in `prismic-reactjs` and `prismic-richtext`).

Now instead of doing `getField(field, 'type')` there are four methods:

* `get(obj, path, defaultValue)` returns a string (via `asText(value).trim()`), this should be the most used method. Example: `get(home, 'data.title')`
* `getCollection(obj, path)` always returns an array from a group field. If something goes wrong, returns the empty array. Example: `getCollection(homepage, 'data.columns').map(...)`
* `getObject(obj, path)` returns an object, e.g. an image. If something goes wrong, returns the empty object. Example: `getObject(author, 'data.image')).thumb`
* `getRichtext(obj, path, defaulValue)` returns a component tree from a rich text field in prismic with all links resolved (via `RichText.render`). Example: `getRichtext(data, 'caption');`